### PR TITLE
Prevent password from being hashed twice

### DIFF
--- a/server/services/users/users.hooks.js
+++ b/server/services/users/users.hooks.js
@@ -65,8 +65,7 @@ module.exports = {
       preventDisabledAdmin()
     ],
     patch: [ 
-      ...restrict, 
-      hashPassword(),
+      ...restrict,
       preventDisabledAdmin()
     ],
     remove: [ 


### PR DESCRIPTION
Currently the reset password feature hashes the password twice before saving it to the database. First by passport, then by the 
hashPassword hook. This prevents the user from logging in after they reset their password. 

By removing the hashPassword in patch, the password is only hashed once.